### PR TITLE
Add careers page for Ucraft

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Please create a pull request to add your company if you work remotely in a good 
 
 ## The list
 ### Armenia
-- Ucraft [Website](https://www.ucraft.com/) - [Linkedin](https://www.linkedin.com/company/ucraft/)
+- Ucraft [Website](https://www.ucraft.com/) - [Linkedin](https://www.linkedin.com/company/ucraft/) - [Careers Page](https://jobs.ucraft.com/jobs/Careers)
 
 ### Switzerland
 - Wisdomise [Website](https://wisdomise.io/) - [Linkedin](https://www.linkedin.com/company/wisdomise/)


### PR DESCRIPTION
Hi Komail,
Thanks for the effort that you put into this!

I think it helps people find the careers section faster if we add a link to each company's `Careers Screen`, as it took me some time to find them myself.

This option can be optional as some companies might not have it.

I added the careers page for `Ucraft` for now as a demonstration, but we can try to find others too.

Bests.
